### PR TITLE
Update dockerfile command

### DIFF
--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -4,4 +4,4 @@ COPY requirements.txt .
 RUN pip3 install --upgrade pip && pip3 install -r requirements.txt
 COPY git-keeper.py .
 RUN ln -s  /config/.netrc ~/.netrc
-ENTRYPOINT ["./git-keeper.py"]
+ENTRYPOINT ["python3", "git-keeper.py"]


### PR DESCRIPTION
With the update to shebang in #29, this updates the Docker command to call the Python executable rather than the script itself. Fixing an error:

```
docker run quay.io/app-sre/git-keeper --config foo --gpgs bar 
Traceback (most recent call last):
  File "/opt/app-root/src/./git-keeper.py", line 11, in <module>
    import sh
ModuleNotFoundError: No module named 'sh'
```