### PR TITLE
Update base image to pyton 3.11

### DIFF
--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/python-39
+FROM registry.access.redhat.com/ubi8/python-311
 LABEL maintainer="Serhii Kryzhnii skryzhni@redhat.com"
 COPY requirements.txt .
 RUN pip3 install --upgrade pip && pip3 install -r requirements.txt

--- a/dockerfiles/Dockerfile.test
+++ b/dockerfiles/Dockerfile.test
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/python-39
+FROM registry.access.redhat.com/ubi8/python-311
 LABEL maintainer="Serhii Kryzhnii skryzhni@redhat.com"
 RUN pip3 install --upgrade pip && pip3 install tox 
 


### PR DESCRIPTION
Found out base image for git-keeper EOL soon, need to rebase it to more recent

**End of life notice: The ubi8/python-39 container image reaches its end of life in May 2024.**