### PR TITLE
APPSRE-10969 add option to use latest commit hash instead of timestamp

### DIFF
--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/python-311
+FROM registry.access.redhat.com/ubi8/python-312
 LABEL maintainer="Serhii Kryzhnii skryzhni@redhat.com"
 COPY requirements.txt .
 RUN pip3 install --upgrade pip && pip3 install -r requirements.txt

--- a/dockerfiles/Dockerfile.test
+++ b/dockerfiles/Dockerfile.test
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/python-311
+FROM registry.access.redhat.com/ubi8/python-312
 LABEL maintainer="Serhii Kryzhnii skryzhni@redhat.com"
 RUN pip3 install --upgrade pip && pip3 install tox 
 

--- a/git-keeper.py
+++ b/git-keeper.py
@@ -20,6 +20,7 @@ import toml
 import argparse
 from urllib.parse import urlparse
 from sretoolbox.utils import retry
+from sh import git
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -28,6 +29,7 @@ logger = logging.getLogger(__name__)
 clone_repo = sh.git.clone.bake("--mirror")
 tar = sh.tar.bake("-cf")
 workdir = "workdir"
+commit = False
 
 
 def cleanwrkdir(workdir):
@@ -52,7 +54,7 @@ def get_s3_client(aws_access_key_id, aws_secret_access_key, region_name, endpoin
 
 
 @retry(max_attempts=5)
-def git_clone_upload(s3_client, gpg, recipients, repo_url, s3_bucket, subfolders, date):
+def git_clone_upload(s3_client, gpg, recipients, repo_url, s3_bucket, subfolders, sub_subfolder):
     logger.info("Processing repo: %s", repo_url)
     if not repo_url.endswith(".git"):
         repo_url = repo_url + ".git"
@@ -72,10 +74,13 @@ def git_clone_upload(s3_client, gpg, recipients, repo_url, s3_bucket, subfolders
             f, recipients=recipients, output=repo_gpg, armor=False, always_trust=True
         )
     object_name = urlparse(repo_url).netloc + urlparse(repo_url).path + ".tar.gpg"
+    if commit:
+        sha = git("--git-dir=" + repo_dir, "rev-parse", "--verify", "HEAD")
+        sub_subfolder = sha
     for subfolder in subfolders:
         logger.info("Uploading repo: %s to subfolder: %s", repo_gpg, subfolder)
         s3_client.upload_file(
-            repo_gpg, s3_bucket, os.path.join(subfolder, date, object_name)
+            repo_gpg, s3_bucket, os.path.join(subfolder, sub_subfolder, object_name)
         )
     cleanwrkdir(workdir)
 
@@ -94,8 +99,15 @@ def main():
         default="",
         help="Path of [comma delimited] subfolder[s]" " in bucket to store backups",
     )
+    parser.add_argument(
+        "--commit",
+        action="store_true",
+        help="use SHA of last commit instead of date as sub-subfolder",
+    )
     args = parser.parse_args()
     subfolders = [str(subfolder) for subfolder in args.subfolders.split(",")]
+    global commit
+    commit = args.commit
 
     cnf = toml.load(open(args.config))
     aws_access_key_id = cnf["s3"]["aws_access_key_id"]


### PR DESCRIPTION
When ding backup for every commit in git-ops environment it might be possible to do sevral backups in same minute, so potentially overwrite previous backup.

To resolve that potential issue - introduce new option `--sha` that changes timestamp to commit SHA in S3 path