### PR TITLE
install gpg and add binary tests

### DIFF
--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -9,7 +9,7 @@ RUN         uv sync --frozen --no-cache --compile-bytecode --no-group dev --pyth
 FROM        registry.access.redhat.com/ubi10/python-314-minimal@sha256:90d72f9275f8f4e7869c42b9a1e25d5cf458c970e15dd3ed072f38a7f07dabd6 AS prod
 USER        0
 RUN         microdnf upgrade -y && \
-    microdnf install -y git tar && \
+    microdnf install -y gpg git tar && \
     microdnf clean all
 WORKDIR     /git-keeper
 RUN         ln -s  /config/.netrc /git-keeper/.netrc
@@ -29,3 +29,4 @@ ENV         UV_NO_CACHE=true
 RUN         uv sync --frozen
 RUN         uv run ruff check --no-fix -v
 RUN         uv run ruff format --check
+RUN         git --version && tar --version && gpg --version


### PR DESCRIPTION
`gpg` is required

```
09:23:36 ERROR:gnupg:Unable to run gpg (gpg) - it may not be available.
09:23:36 Traceback (most recent call last):
09:23:36   File "/git-keeper/.venv/lib64/python3.14/site-packages/gnupg.py", line 1159, in __init__
09:23:36     p = self._open_subprocess(['--list-config', '--with-colons'])
09:23:36   File "/git-keeper/.venv/lib64/python3.14/site-packages/gnupg.py", line 1229, in _open_subprocess
09:23:36     result = Popen(cmd, shell=False, stdin=PIPE, stdout=PIPE, stderr=PIPE, startupinfo=si, env=self.env)
09:23:36   File "/usr/lib64/python3.14/subprocess.py", line 1039, in __init__
09:23:36     self._execute_child(args, executable, preexec_fn, close_fds,
09:23:36     ~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
09:23:36                         pass_fds, cwd, env,
09:23:36                         ^^^^^^^^^^^^^^^^^^^
09:23:36     ...<5 lines>...
09:23:36                         gid, gids, uid, umask,
09:23:36                         ^^^^^^^^^^^^^^^^^^^^^^
09:23:36                         start_new_session, process_group)
09:23:36                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
09:23:36   File "/usr/lib64/python3.14/subprocess.py", line 1990, in _execute_child
09:23:36     raise child_exception_type(errno_num, err_msg, err_filename)
09:23:36 FileNotFoundError: [Errno 2] No such file or directory: 'gpg'
```