### PR TITLE
fix: set HOME and GIT_TERMINAL_PROMPT for .netrc credential lookup

### DIFF
--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -15,6 +15,8 @@ WORKDIR     /git-keeper
 RUN         ln -s  /config/.netrc /git-keeper/.netrc
 RUN         chown -R 1001:0 /git-keeper
 USER        1001
+ENV         HOME=/git-keeper
+ENV         GIT_TERMINAL_PROMPT=0
 ENV         VIRTUAL_ENV=/git-keeper/.venv
 ENV         PATH="$VIRTUAL_ENV/bin:$PATH"
 COPY        --from=builder /git-keeper /git-keeper


### PR DESCRIPTION
## Summary
- The `ubi10/python-314-minimal` base image sets `HOME=/opt/app-root/src`, unlike the previous `ubi9/ubi-minimal` image. This broke git's `.netrc` credential lookup since the symlink lives at `/git-keeper/.netrc`.
- Set `HOME=/git-keeper` so git finds `.netrc` again.
- Set `GIT_TERMINAL_PROMPT=0` to prevent git from attempting interactive credential prompts in the container.

## Test plan
- [ ] Verify private GitLab repos that were failing now clone successfully
- [ ] Verify public GitHub repos still work