### PR TITLE
fix: remove GIT_TERMINAL_PROMPT=0 to restore .netrc credential flow

### DIFF
--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -16,7 +16,6 @@ RUN         ln -s  /config/.netrc /git-keeper/.netrc
 RUN         chown -R 1001:0 /git-keeper
 USER        1001
 ENV         HOME=/git-keeper
-ENV         GIT_TERMINAL_PROMPT=0
 ENV         VIRTUAL_ENV=/git-keeper/.venv
 ENV         PATH="$VIRTUAL_ENV/bin:$PATH"
 COPY        --from=builder /git-keeper /git-keeper


### PR DESCRIPTION
## Summary

- Remove `GIT_TERMINAL_PROMPT=0` from Dockerfile while keeping `HOME=/git-keeper`
- `HOME=/git-keeper` ensures git/curl finds `.netrc` via the existing symlink, providing credentials for both GitHub and GitLab repos
- Without `GIT_TERMINAL_PROMPT=0`, inaccessible private repos fail with `"No such device or address"` (matching the existing skip logic in `git-keeper.py`)

## Root cause

The ubi9→ubi10 migration changed libcurl from 7.76.1 to 8.12.1 and tightened the default crypto policy (`-kRSA`, post-quantum groups). This caused 34 GitLab repos to require explicit credentials where previously unauthenticated clone worked. Since `HOME` was never set correctly (defaulted to `/` on ubi9, `/opt/app-root/src` on ubi10), the `.netrc` symlink at `/git-keeper/.netrc` was never found by git — credentials were never actually used.

Setting `HOME=/git-keeper` (from the previous commit) fixes the `.netrc` lookup. Removing `GIT_TERMINAL_PROMPT=0` (also from the previous commit) restores the error message that the skip logic expects for private repos the bot cannot access.

## Test plan

- [ ] Verify GitLab repos (e.g. `giskard.git`, `configuration.git`) clone successfully
- [ ] Verify GitHub private repos are skipped with WARNING (not ERROR)
- [ ] Verify 0 errors in the Jenkins run